### PR TITLE
Truly promisify

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/Poddify/aws-common#readme",
   "dependencies": {
-    "aws-sdk": "^2.273.1",
+    "aws-sdk": "2.339.0",
     "dynamodb-doc": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "homepage": "https://github.com/Poddify/aws-common#readme",
   "dependencies": {
-    "aws-sdk": "2.339.0",
-    "dynamodb-doc": "^1.0.0"
+    "aws-sdk": "2.339.0"
   },
   "devDependencies": {
     "@poddify/eslint-config-poddify": "^1.0.1",

--- a/src/dynamodb/get.js
+++ b/src/dynamodb/get.js
@@ -1,6 +1,6 @@
-import doc from 'dynamodb-doc';
+import AWS from 'aws-sdk';
 
-const dynamoDb = new doc.DynamoDB();
+const dynamoDb = new AWS.DynamoDB();
 
 export default (item, table) =>
     dynamoDb.getItem({

--- a/src/dynamodb/get.js
+++ b/src/dynamodb/get.js
@@ -1,10 +1,9 @@
 import doc from 'dynamodb-doc';
-import promisify from '../util/promisify';
 
 const dynamoDb = new doc.DynamoDB();
 
 export default (item, table) =>
-    promisify(dynamoDb.getItem)({
+    dynamoDb.getItem({
         TableName: table,
         Key: item
-    });
+    }).promise();

--- a/src/dynamodb/put.js
+++ b/src/dynamodb/put.js
@@ -1,10 +1,9 @@
 import doc from 'dynamodb-doc';
-import promisify from '../util/promisify';
 
 const dynamoDb = new doc.DynamoDB();
 
 export default (item, table) =>
-    promisify(dynamoDb.putItem)({
+    dynamoDb.putItem({
         TableName: table,
         Item: item
-    });
+    }).promise();

--- a/src/dynamodb/put.js
+++ b/src/dynamodb/put.js
@@ -1,6 +1,6 @@
-import doc from 'dynamodb-doc';
+import AWS from 'aws-sdk';
 
-const dynamoDb = new doc.DynamoDB();
+const dynamoDb = new AWS.DynamoDB();
 
 export default (item, table) =>
     dynamoDb.putItem({

--- a/src/sns/publish.js
+++ b/src/sns/publish.js
@@ -1,11 +1,10 @@
 import AWS from 'aws-sdk';
-import promisify from '../util/promisify';
 
 const SNS = new AWS.SNS();
 
 export default (topic, subject, message) =>
-    promisify(SNS.publish)({
+    SNS.publish({
         TopicArn: topic,
         Subject: subject,
         Message: message
-    });
+    }).promise();

--- a/src/util/promisify.js
+++ b/src/util/promisify.js
@@ -1,9 +1,0 @@
-export default handler => (...args) =>
-    new Promise((resolve, reject) => {
-        handler(...args, (err, data) => {
-            if (err) return reject(err);
-
-            return resolve(data);
-        });
-    });
-

--- a/test/unit/dynamodb/get.spec.js
+++ b/test/unit/dynamodb/get.spec.js
@@ -22,7 +22,7 @@ describe('Feature: GET from DynamoDB', () => {
         const DynamoDB = sinon.stub().returns(dynamoMock);
 
         const get = loadModule({
-            'dynamodb-doc': {
+            'aws-sdk': {
                 DynamoDB
             }
         });

--- a/test/unit/dynamodb/put.spec.js
+++ b/test/unit/dynamodb/put.spec.js
@@ -1,4 +1,3 @@
-import doc from 'dynamodb-doc';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
 import { expect } from 'chai';
@@ -6,31 +5,36 @@ import { expect } from 'chai';
 const MODULE = '../../../src/dynamodb/put';
 const loadModule = stubs => proxyquire(MODULE, { ...stubs }).default;
 
-describe.skip('Feature: PUT to DynamoDB', () => {
-    afterEach(sinon.restore);
-
-    it('Scenario: puts data to a DynamoDB table', () => {
-        const item = Symbol('data to put');
+describe('Feature: PUT from DynamoDB', () => {
+    it('Scenario: puts data into a DynamoDB table', async () => {
+        const item = Symbol('data to insert');
         const table = Symbol('table to put data into');
+        const expectedResults = Symbol('expected dynamo db put results');
 
-        const promisify = sinon.stub();
-        const promisifiedPut = sinon.stub();
+        const putItemPromiseStub = sinon.stub().resolves(expectedResults);
+        const putItemStub = sinon.stub().returns({
+            promise: putItemPromiseStub
+        });
+        const dynamoMock = {
+            putItem: putItemStub
+        };
 
-        // FIXME:
-        const dynamoDb = sinon.createStubInstance(doc.DynamoDB);
-
-        promisify.withArgs(dynamoDb.putItem).returns(promisifiedPut);
+        const DynamoDB = sinon.stub().returns(dynamoMock);
 
         const put = loadModule({
-            '../util/promisify': promisify
+            'dynamodb-doc': {
+                DynamoDB
+            }
         });
 
-        put(item, table);
+        const results = await put(item, table);
 
-        expect(promisifiedPut.callCount).to.equal(1);
-        expect(promisifiedPut.firstCall.args).to.deep.equal({
+        expect(results).to.equal(expectedResults);
+        expect(putItemStub.callCount, 'should call putItem').to.equal(1);
+        expect(putItemPromiseStub.callCount, 'should call putItem(..).promise').to.equal(1);
+        expect(putItemStub.firstCall.args).to.deep.equal([{
             TableName: table,
             Item: item
-        });
+        }]);
     });
 });

--- a/test/unit/dynamodb/put.spec.js
+++ b/test/unit/dynamodb/put.spec.js
@@ -22,7 +22,7 @@ describe('Feature: PUT from DynamoDB', () => {
         const DynamoDB = sinon.stub().returns(dynamoMock);
 
         const put = loadModule({
-            'dynamodb-doc': {
+            'aws-sdk': {
                 DynamoDB
             }
         });


### PR DESCRIPTION
fixes #3 
fixes #2 

🤦‍♂️ `aws-sdk` exposes a promise interface as of `2.3.x`. This PR bumps `aws-sdk` and replaces all of my obnoxious manual promisifying w/ the versions exposed natively. It also removes the `dynamodb-doc` dependency (last update was >4yrs ago!!!) in favor of using `aws-sdk` directly for DynamoDB.